### PR TITLE
Binding Errors

### DIFF
--- a/lifecycleaware-compiler/src/main/java/com/jzallas/lifecycleaware/compiler/generators/TargetBinderGenerator.java
+++ b/lifecycleaware-compiler/src/main/java/com/jzallas/lifecycleaware/compiler/generators/TargetBinderGenerator.java
@@ -59,19 +59,20 @@ public class TargetBinderGenerator extends AbstractClassGenerator {
     }
 
     private CodeBlock buildBindingOne(Element element) {
-        final String exceptionParamName = "exception";
         final String lifecycleBindingExceptionType = "uninitializedFailure";
 
         return CodeBlock.builder()
-                .beginControlFlow("try")
+                .beginControlFlow("if ($L.$L != $L)",
+                        PARAM_NAME_TARGET,
+                        element.getSimpleName(),
+                        null)
                 .add(observerStatement(element))
-                .nextControlFlow("catch ($T $L)", NullPointerException.class, exceptionParamName)
+                .nextControlFlow("else")
                 .addStatement(
-                        "throw $T.$L($L, $L)",
+                        "throw $T.$L($L)",
                         LifecycleBindingException.class,
                         lifecycleBindingExceptionType,
-                        PARAM_NAME_LIFECYCLE,
-                        exceptionParamName
+                        PARAM_NAME_TARGET
                 )
                 .endControlFlow()
                 .build();

--- a/lifecycleaware-compiler/src/main/java/com/jzallas/lifecycleaware/compiler/producers/TargetBinderNameProducer.java
+++ b/lifecycleaware-compiler/src/main/java/com/jzallas/lifecycleaware/compiler/producers/TargetBinderNameProducer.java
@@ -7,7 +7,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.util.Elements;
 
 public class TargetBinderNameProducer implements ClassNameProducer {
-    private static final String BINDER_CLASS_SUFFIX = LifecycleAware.class.getSimpleName() + "Binder";
+    private static final String BINDER_CLASS_SUFFIX = "Binder";
     private Elements elements;
 
     public TargetBinderNameProducer(Elements elements) {
@@ -17,7 +17,7 @@ public class TargetBinderNameProducer implements ClassNameProducer {
 
     @Override
     public ClassName getClassName(Element element) {
-        String className = join(element.getSimpleName(), BINDER_CLASS_SUFFIX);
+        String className = join(element.getSimpleName(), LifecycleAware.class.getSimpleName(), BINDER_CLASS_SUFFIX);
         String packageName = elements.getPackageOf(element).getQualifiedName().toString();
         return ClassName.get(packageName, className);
     }

--- a/lifecycleaware/src/main/java/com/jzallas/lifecycleaware/LifecycleBindingException.java
+++ b/lifecycleaware/src/main/java/com/jzallas/lifecycleaware/LifecycleBindingException.java
@@ -9,10 +9,10 @@ public final class LifecycleBindingException extends RuntimeException {
         return new LifecycleBindingException(bindingFailureMessage(target), throwable);
     }
 
-    public static LifecycleBindingException uninitializedFailure(Object target, Throwable throwable) {
+    public static LifecycleBindingException uninitializedFailure(Object target) {
         final String reminderTemplate = "Did you remember to initialize the observer before calling %s.bind()?";
         final String initFailMessage = String.format(reminderTemplate, LifecycleBinder.class.getSimpleName());
-        return new LifecycleBindingException(bindingFailureMessage(target) + initFailMessage, throwable);
+        return new LifecycleBindingException(bindingFailureMessage(target) + " " + initFailMessage);
     }
 
     private static String bindingFailureMessage(Object target) {
@@ -21,5 +21,9 @@ public final class LifecycleBindingException extends RuntimeException {
 
     private LifecycleBindingException(String string, Throwable throwable) {
         super(string, throwable);
+    }
+
+    private LifecycleBindingException(String string) {
+        super(string);
     }
 }

--- a/lifecycleaware/src/test/java/com/jzallas/lifecycleaware/LifecycleBinderTest.java
+++ b/lifecycleaware/src/test/java/com/jzallas/lifecycleaware/LifecycleBinderTest.java
@@ -12,6 +12,10 @@ import org.mockito.MockitoAnnotations;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
 public class LifecycleBinderTest {
 
     @Mock
@@ -32,18 +36,34 @@ public class LifecycleBinderTest {
     }
 
     @Test(expected = LifecycleBindingException.class)
-    public void testConstructorExceptionFailure() throws Exception {
-        validateFailure(Mockito.mock(InvocationTargetException.class));
+    public void testConstructorKnownExceptionFailure() throws Exception {
+        InvocationTargetException targetException = mock(InvocationTargetException.class);
+        LifecycleBindingException bindingException = mock(LifecycleBindingException.class);
+
+        doReturn(bindingException)
+                .when(targetException)
+                .getTargetException();
+        try {
+            validateFailure(targetException);
+        } catch (LifecycleBindingException exception) {
+            assertSame(bindingException, exception);
+            throw exception;
+        }
+    }
+
+    @Test(expected = LifecycleBindingException.class)
+    public void testConstructorUnknownExceptionFailure() throws Exception {
+        validateFailure(mock(InvocationTargetException.class));
     }
 
     @Test(expected = LifecycleBindingException.class)
     public void testConstructorNotVisibleFailure() throws Exception {
-        validateFailure(Mockito.mock(IllegalAccessException.class));
+        validateFailure(mock(IllegalAccessException.class));
     }
 
     @Test(expected = LifecycleBindingException.class)
     public void testAbstractClassFailure() throws Exception {
-        validateFailure(Mockito.mock(InstantiationException.class));
+        validateFailure(mock(InstantiationException.class));
     }
 
     private void validateFailure(Throwable throwable) throws Exception {
@@ -75,8 +95,8 @@ public class LifecycleBinderTest {
     }
 
     @SuppressWarnings("unused")
-    private static class TestTargetLifecycleAwareBinder {
-        public TestTargetLifecycleAwareBinder(TestTarget target, Lifecycle lifecycle) {
+    private static class TestTarget_LifecycleAware_Binder {
+        public TestTarget_LifecycleAware_Binder(TestTarget target, Lifecycle lifecycle) {
             // stub
         }
     }


### PR DESCRIPTION
    Corrected binding errors that get propagated when observer is null
    Corrected binding class name in Binder
    Added NonNull binding params to at least warn when Binder is misused